### PR TITLE
Fixed Oracle Linux 7 synced folders

### DIFF
--- a/Oracle-Linux/7/server/environment.yml
+++ b/Oracle-Linux/7/server/environment.yml
@@ -23,6 +23,8 @@ nodes:
     mem: 512
     provision: false
     provisioners: []
+    synced_folder:
+      type: rsync
     vcpu: 1
     port_forwards: []
     windows: false


### PR DESCRIPTION
- After doing some regression testing with updated Packer templates, it
was discovered that VirtualBox guest additions for share folders is not
functional. Changed synced folders to use rsync for now.